### PR TITLE
🔧 Increase number of rq workers per container

### DIFF
--- a/bin/worker.conf
+++ b/bin/worker.conf
@@ -20,6 +20,8 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL for a unix socket
 
 [program:rqworker]
+process_name=%(program_name)s_%(process_num)02d
+numprocs=10
 command=python manage.py rqworker default
 stderr_logfile=/dev/stdout
 stderr_logfile_maxbytes=0


### PR DESCRIPTION
Increases number of workers per container to account for blocking network requests in python.