### PR TITLE
🔧 Decrease worker timeout for queues

### DIFF
--- a/coordinator/settings.py
+++ b/coordinator/settings.py
@@ -149,7 +149,7 @@ def get_queues():
             'HOST': os.environ.get('REDIS_HOST', 'localhost'),
             'PORT': os.environ.get('REDIS_PORT', 6379),
             'DB': 0,
-            'DEFAULT_TIMEOUT': 360,
+            'DEFAULT_TIMEOUT': 30,
         },
         'health_checks': {
             'HOST': os.environ.get('REDIS_HOST', 'localhost'),


### PR DESCRIPTION
Tasks should not take very long to complete as they are only responsible for sending web requests and updating the database.