### PR TITLE
🔧 Tune down numprocs to utilize less memory

### DIFF
--- a/bin/worker.conf
+++ b/bin/worker.conf
@@ -21,7 +21,7 @@ serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL for a unix socket
 
 [program:rqworker]
 process_name=%(program_name)s_%(process_num)02d
-numprocs=10
+numprocs=5
 command=python manage.py rqworker default
 stderr_logfile=/dev/stdout
 stderr_logfile_maxbytes=0


### PR DESCRIPTION
10 worker procs was saturating the container's memory. Cutting it in half.