### PR TITLE
✨ Check for staged and published states in task

### DIFF
--- a/coordinator/settings.py
+++ b/coordinator/settings.py
@@ -229,8 +229,8 @@ EGO_API = os.environ.get('EGO_URL', None)
 DATASERVICE_API = os.environ.get('DATASERVICE_URL', None)
 
 # Timeouts in seconds
-TASK_TIMEOUT = 1600
-RELEASE_TIMEOUT = 3600
+TASK_TIMEOUT = 160000
+RELEASE_TIMEOUT = 360000
 
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
Takes care of `staged` and `published` transitions during status checks.
Should be merged with code in the task view file eventually.