### PR TITLE
✨ Filter by state

### DIFF
--- a/coordinator/api/views/release.py
+++ b/coordinator/api/views/release.py
@@ -5,6 +5,7 @@ from rest_framework import viewsets
 from rest_framework.mixins import UpdateModelMixin
 from rest_framework.decorators import action
 from rest_framework.response import Response
+import django_filters.rest_framework
 from coordinator.authentication import EgoAuthentication
 from coordinator.tasks import (
     init_release,
@@ -15,6 +16,13 @@ from coordinator.tasks import (
 from coordinator.permissions import GroupPermission
 from coordinator.api.models import Release
 from coordinator.api.serializers import ReleaseSerializer
+
+
+class ReleaseFilter(django_filters.FilterSet):
+
+    class Meta:
+        model = Release
+        fields = ('state',)
 
 
 class ReleaseViewSet(viewsets.ModelViewSet, UpdateModelMixin):
@@ -36,6 +44,8 @@ class ReleaseViewSet(viewsets.ModelViewSet, UpdateModelMixin):
     lookup_field = 'kf_id'
     queryset = Release.objects.order_by('-created_at').all()
     serializer_class = ReleaseSerializer
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
+    filter_class = ReleaseFilter
 
     def create(self, *args, **kwargs):
         """

--- a/coordinator/api/views/task.py
+++ b/coordinator/api/views/task.py
@@ -12,7 +12,7 @@ class TaskFilter(django_filters.FilterSet):
 
     class Meta:
         model = Task
-        fields = ('release', 'task_service')
+        fields = ('release', 'task_service', 'state')
 
 
 class TaskViewSet(viewsets.ModelViewSet):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -67,6 +67,13 @@ def test_task_filters(client, db, task):
     count = resp.json()['count']
     assert count == 1
 
+    # State filter
+    resp = client.get(BASE_URL+'/tasks?state=blah')
+    assert resp.json()['count'] == 0
+
+    resp = client.get(BASE_URL+'/tasks?state=pending')
+    assert resp.json()['count'] == 1
+
 
 def test_task_relations(client, transactional_db, task):
     """ Test basic response """


### PR DESCRIPTION
Allows releases and tasks to be filtered by state.
This means that searching for `/releases?state=published` will return a descending list of published releases and will be able to provide the latest available version.

Fixes #102 