### PR TITLE
♻️ Use response content instead of json for log dumps

### DIFF
--- a/coordinator/tasks.py
+++ b/coordinator/tasks.py
@@ -100,7 +100,7 @@ def init_task(release_id, task_service_id, task_id):
                              timeout=settings.REQUEST_TIMEOUT)
     except requests.exceptions.RequestException:
         failed = True
-        logger.error(f'problem requesting task for init: {resp.json()}')
+        logger.error(f'problem requesting task for init: {resp.content}')
 
     if resp and resp.status_code != 200:
         logger.error(f' invalid code from task for init: {resp.status_code}')
@@ -146,7 +146,7 @@ def start_release(release_id):
                                  timeout=settings.REQUEST_TIMEOUT)
             resp.raise_for_status()
         except requests.exceptions.RequestException:
-            logger.error(f'problem requesting task for start: {resp.json()}')
+            logger.error(f'problem requesting task for start: {resp.content}')
             failed = True
 
         # Check that command was accepted
@@ -158,7 +158,7 @@ def start_release(release_id):
         if (resp and 'state' in resp.json() and
            resp.json()['state'] != 'running'):
             logger.error(f'invalid state returned from task for start: ' +
-                         '{resp.json()}')
+                         '{resp.content}')
             failed = True
 
         if failed:
@@ -203,7 +203,8 @@ def publish_release(release_id):
                                  timeout=settings.REQUEST_TIMEOUT)
             resp.raise_for_status()
         except requests.exceptions.RequestException:
-            logger.error(f'problem requesting task for publish: {resp.json()}')
+            logger.error(f'problem requesting task for publish: ' +
+                         f'{resp.content}')
             failed = True
 
         # Check that command was accepted
@@ -215,7 +216,7 @@ def publish_release(release_id):
         if (resp and 'state' in resp.json() and
            resp.json()['state'] != 'publishing'):
             logger.error(f'invalid state returned from task for publish: ' +
-                         '{resp.json()}')
+                         '{resp.content}')
             failed = True
 
         if failed:


### PR DESCRIPTION
Use `response.content` as `response.json()` may not always be available.