### PR TITLE
🔧 Include jwt in Authorization header in requests to task's /status

### DIFF
--- a/coordinator/api/models/taskservice.py
+++ b/coordinator/api/models/taskservice.py
@@ -65,6 +65,7 @@ class TaskService(models.Model):
         """
         try:
             resp = requests.get(self.url+'/status',
+                                headers=settings.EGO_JWT.header,
                                 timeout=settings.REQUEST_TIMEOUT)
             resp.raise_for_status()
         except RequestException:

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -57,7 +57,10 @@ def test_full_release(client, transactional_db, mocker, worker, study):
     ts = TaskService.objects.first()
     ts.health_check()
     assert mock_requests.get.call_count == 1
-    mock_requests.get.assert_called_with('http://ts.com/status', timeout=0.1)
+    headers = {'Authorization': 'Bearer abc'}
+    mock_requests.get.assert_called_with('http://ts.com/status',
+                                         headers=headers,
+                                         timeout=0.1)
 
     # Start release
     release = {

--- a/tests/test_task_services.py
+++ b/tests/test_task_services.py
@@ -195,7 +195,9 @@ def test_task_service_bad_status(client, db, task_service):
         ts.health_check()
         assert mock_requests.get.call_count == 1
         assert ts.health_status == 'ok'
+        headers = {'Authorization': 'Bearer abc'}
         mock_requests.get.assert_called_with('http://ts.com/status',
+                                             headers=headers,
                                              timeout=0.1)
         assert ts.last_ok_status == 1
         ts.health_check()


### PR DESCRIPTION
Includes Ego JWT when checking status of a task service.