### PR TITLE
📌 Set python to version 3.6 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM        python:3-alpine3.7
+FROM        python:3.6-alpine3.7
 
 ADD         requirements.txt /app/
 WORKDIR     /app


### PR DESCRIPTION
`Django-rq` has not released an update that changes an `async` naming conflict which breaks when trying to install under python 3.7. This pins the docker container to using 3.6 to avoid this conflict until it has been released.