### PR TITLE
⬆️ Bump urllib3 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ djangorestframework==3.8.2
 gunicorn==19.7.1
 psycopg2==2.7.4
 requests==2.20.0
-urllib3==1.22
+urllib3==1.24.1
 base32-crockford==0.3.0
 django-rq==1.2.0
 rq==0.12.0


### PR DESCRIPTION
Addresses security vuln in 1.22.