### PR TITLE
🏷 Release 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# Kids First Release Coordinator Release 1.5.0
+
+## Features
+
+### Summary
+
+Feature Emojis: 📌x2 ✨x1 ⬆️x1 🔧x1
+Feature Labels: [bug](https://api.github.com/repos/kids-first/kf-api-release-coordinator/labels/bug) x3 [feature](https://api.github.com/repos/kids-first/kf-api-release-coordinator/labels/feature) x2 [refactor](https://api.github.com/repos/kids-first/kf-api-release-coordinator/labels/refactor) x1
+
+### New features and changes
+
+- (#122) ✨ Adds last_published fields to study model - @dankolbman
+- (#126) ⬆️ Bump urllib3 dependency - @dankolbman
+- (#125) 📌 Pin redis requirements - @dankolbman
+- (#123) 📌 Set python to version 3.6 in Dockerfile - @dankolbman
+- (#121) 🔧 Include jwt in Authorization header in requests to task's /status - @dankolbman
+
+
 # Kids First Release Coordinator Release 1.4.0
 
 ## Features

--- a/coordinator/urls.py
+++ b/coordinator/urls.py
@@ -15,7 +15,7 @@ with open(os.path.join(dir_path, 'README.md'), 'r') as f:
 schema_view = get_schema_view(
    openapi.Info(
       title="Release Coordinator API",
-      default_version='1.4.0',
+      default_version='1.5.0',
       description=description,
       license=openapi.License(name="Apache 2.0"),
    ),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="kf-api-coordinator",
-    version="1.4.0",
+    version="1.5.0",
     description="Release Coordinator",
     license="Apache 2",
     packages=find_packages()


### PR DESCRIPTION
# Kids First Release Coordinator Release 1.5.0

## Features

### Summary

Feature Emojis: 📌x2 ✨x1 ⬆️x1 🔧x1
Feature Labels: [bug](https://api.github.com/repos/kids-first/kf-api-release-coordinator/labels/bug) x3 [feature](https://api.github.com/repos/kids-first/kf-api-release-coordinator/labels/feature) x2 [refactor](https://api.github.com/repos/kids-first/kf-api-release-coordinator/labels/refactor) x1

### New features and changes

- (#122) ✨ Adds last_published fields to study model - @dankolbman
- (#126) ⬆️ Bump urllib3 dependency - @dankolbman
- (#125) 📌 Pin redis requirements - @dankolbman
- (#123) 📌 Set python to version 3.6 in Dockerfile - @dankolbman
- (#121) 🔧 Include jwt in Authorization header in requests to task's /status - @dankolbman