### PR TITLE
🐛 Set default settings module for wsgi entry

### DIFF
--- a/coordinator/wsgi.py
+++ b/coordinator/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "coordinator.settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings.base")
 
 application = get_wsgi_application()


### PR DESCRIPTION
The default django settings module was wrong when launched through wsgi entry point through gunicorn.