### PR TITLE
🐛 Improve compose for dev

### DIFF
--- a/bin/run_dev.sh
+++ b/bin/run_dev.sh
@@ -1,0 +1,2 @@
+python /app/manage.py migrate
+python /app/manage.py runserver 0.0.0.0:5000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,13 +10,11 @@ services:
   coordinator:
     build: .
     image: coordinator:latest
-    command: ['./bin/wait-for-pg.sh', 'pg', './manage.py runserver']
+    command: ['./bin/wait-for-pg.sh', 'pg', './bin/run_dev.sh']
     volumes:
       - ./:/app/
-    external_links:
-      - task
     ports:
-      - '8000:80'
+      - '5000:5000'
     environment:
       - PG_NAME=coordinator
       - PG_HOST=pg


### PR DESCRIPTION
The docker-compose didn't apply migrations before beginning the development server.
This adds a script to handle the migrations, then start the dev server as the entrypoint in the compose file.