### PR TITLE
🔥 Remove setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,0 @@
-[tool:pytest]
-pep8ignore =
-    migrations/*.py ALL
-    settings.py ALL


### PR DESCRIPTION
Removes `setup.cfg` which is a duplicate of the contents of `pytest.ini`.