### PR TITLE
🐛 Fix static paths

### DIFF
--- a/coordinator/settings/development.py
+++ b/coordinator/settings/development.py
@@ -260,7 +260,7 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATIC_ROOT = '/static/'
 STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, "static")
+    os.path.join(BASE_DIR, '../', 'static')
 ]
 
 # APIs

--- a/coordinator/settings/production.py
+++ b/coordinator/settings/production.py
@@ -260,7 +260,7 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATIC_ROOT = '/static/'
 STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, "static")
+    os.path.join(BASE_DIR, '../', 'static')
 ]
 
 # APIs

--- a/coordinator/settings/testing.py
+++ b/coordinator/settings/testing.py
@@ -163,7 +163,7 @@ USE_TZ = True
 STATIC_URL = '/static/'
 STATIC_ROOT = '/static/'
 STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, "static")
+    os.path.join(BASE_DIR, '../', 'static')
 ]
 
 # APIs


### PR DESCRIPTION
Static paths are generated relative to the settings path, which got relocated to within the `coordinator` directory. This updates the static path to use the parent directory.