### PR TITLE
🐛 Update testing with correct apps

### DIFF
--- a/coordinator/settings/testing.py
+++ b/coordinator/settings/testing.py
@@ -20,10 +20,18 @@ APPEND_SLASH = False
 
 INSTALLED_APPS = [
     'coordinator.api.apps.ApiConfig',
+    'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
     'rest_framework',
-    'drf_yasg'
+    'django_filters',
+    'django_rq',
+    'drf_yasg',
+    'django_fsm',
+    'corsheaders',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
The `testing` settings did not have all the correct apps installed that development and production had, which caused things to fail when running with `testing`.