### PR TITLE
🙈 Ignore ci files in jenkins

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -6,3 +6,4 @@ pep8ignore =
   */migrations/*.py ALL
   coordinator/wsgi.py ALL
   manage.py ALL
+  kf-api-release-coordinator-config/* ALL


### PR DESCRIPTION
Jenkins fails pep8 because the -config repo files are not being ignored.