### PR TITLE
🔥 Replace pep8 with codestyle

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,9 @@
 pytest==3.5.0
 pytest-django==3.1.2
-pep8==1.7.1
-pytest-pep8==1.0.6
 mock==2.0.0
 pytest-mock==1.9.0
 coverage==4.5.1
 pytest-cov==2.5.1
 codacy-coverage==1.3.11
+pycodestyle==2.5.0
+pytest-codestyle==1.4.0

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,9 +1,8 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = coordinator.settings.testing
-addopts = --pep8
-pep8ignore =
-  coordinator/settings/*.py ALL
-  */migrations/*.py ALL
-  coordinator/wsgi.py ALL
-  manage.py ALL
-  kf-api-release-coordinator-config/* ALL
+addopts = --codestyle
+codestyle_exclude =
+  coordinator/api/*
+  coordinator/wsgi.py
+  manage.py
+  kf-api-release-coordinator-config/*


### PR DESCRIPTION
Discovered that the `pep8` package was replaced with `pycodestyle` almost 5 years ago by direct orders from the BDFL.... oops.