### PR TITLE
🐛 Allow releases to re-enter cancelling state

### DIFF
--- a/coordinator/api/models/release.py
+++ b/coordinator/api/models/release.py
@@ -12,9 +12,15 @@ from semantic_version.django_fields import VersionField
 from coordinator.utils import kf_id_generator
 from coordinator.api.models.study import Study
 
-# Allowed source statse for release cancels and fails
-CANCEL_SOURCES = ['waiting', 'initializing', 'running', 'staged', 'publishing']
-FAIL_SOURCES = CANCEL_SOURCES+['canceling']
+# Allowed source states for failuer
+FAIL_SOURCES = [
+    'waiting',
+    'initializing',
+    'running',
+    'staged',
+    'publishing',
+    'canceling',
+]
 
 
 logger = logging.getLogger()
@@ -112,7 +118,7 @@ class Release(models.Model):
         self.save()
         return
 
-    @transition(field=state, source=CANCEL_SOURCES, target='canceling')
+    @transition(field=state, source=FAIL_SOURCES, target='canceling')
     def cancel(self):
         """ Cancel the release """
         return

--- a/coordinator/api/models/task.py
+++ b/coordinator/api/models/task.py
@@ -126,7 +126,9 @@ class Task(models.Model):
                 self.failed()
                 self.release.cancel()
                 self.release.save()
-                django_rq.enqueue(cancel_release, self.release.kf_id)
+                django_rq.enqueue(cancel_release,
+                                  self.release.kf_id,
+                                  fail=True)
                 return
             elif resp['state'] == 'staged' and self.state != 'staged':
                 self.stage()

--- a/tests/failures/test_fail_cancel_release.py
+++ b/tests/failures/test_fail_cancel_release.py
@@ -1,0 +1,46 @@
+import os
+import json
+import pytest
+import mock
+import requests
+from coordinator.api.models import Release, Study, Task, TaskService, Event
+
+
+def test_fail_cancel(admin_client, dev_client, client, transactional_db,
+                     mocker, worker, task_service, study):
+    """
+    Test that when a cancel_release task fails and the release not set to
+    a terminal state (canceled, failed), then the status_checks on the
+    releases's tasks are unable to re-invoke the cancel_release task because
+    they hit an unallowed transition before trying to enqueue the task
+    """
+    # Our task should respond 'failed' during status check, even though
+    # it is 'running' internally
+    mock_task_requests = mocker.patch('coordinator.api.models.task.requests')
+    mock_task_action = mock.Mock()
+    mock_task_action.status_code = 200
+    mock_task_action.json.return_value = {'state': 'failed'}
+    mock_task_requests.post.return_value = mock_task_action
+
+    # Our release is in the 'canceling' state and `cancel_release` task is
+    # yet to be called
+    release = Release(name='test', tags=[])
+    release.state = 'canceling'
+    release.save()
+    task = Task('TA_00000000',
+                release=release,
+                task_service=TaskService.objects.first(),
+                state='running')
+    task.save()
+    # The status check should call the `cancel_release` task to update the
+    # release state and the task state to failed
+    task.status_check()
+
+    assert release.state == 'canceling'
+
+    worker.work(burst=True)
+
+    release = Release.objects.get(kf_id=task.release_id)
+
+    assert task.state == 'failed'
+    assert release.state == 'failed'


### PR DESCRIPTION
Releases were attempting to re-enter canceling state and were thus raising an error before being able to enqueue a task to get them out of that state.
This allows releases to change to `canceling` state cyclically so that the `cancel_release` task may be called to move the release to the `canceled` or `failed` state.

Fixes #136 