### PR TITLE
✨ Add auth0 token validation

### DIFF
--- a/coordinator/api/views/release.py
+++ b/coordinator/api/views/release.py
@@ -6,7 +6,7 @@ from rest_framework.mixins import UpdateModelMixin
 from rest_framework.decorators import action
 from rest_framework.response import Response
 import django_filters.rest_framework
-from coordinator.authentication import EgoAuthentication
+from coordinator.authentication import Auth0Authentication, EgoAuthentication
 from coordinator.tasks import (
     init_release,
     publish_release,
@@ -39,7 +39,7 @@ class ReleaseViewSet(viewsets.ModelViewSet, UpdateModelMixin):
     partial_update:
     Updates a release given a `kf_id` replacing only specified fields
     """
-    authentication_classes = (EgoAuthentication,)
+    authentication_classes = (Auth0Authentication, EgoAuthentication,)
     permission_classes = (GroupPermission,)
     lookup_field = 'kf_id'
     queryset = Release.objects.order_by('-created_at').all()

--- a/coordinator/api/views/task_service.py
+++ b/coordinator/api/views/task_service.py
@@ -3,7 +3,7 @@ from rest_framework import viewsets
 import django_filters.rest_framework
 from rest_framework.decorators import action
 from rest_framework.response import Response
-from coordinator.authentication import EgoAuthentication
+from coordinator.authentication import Auth0Authentication, EgoAuthentication
 from coordinator.permissions import DevPermission
 from coordinator.tasks import health_check
 from coordinator.api.models import TaskService
@@ -39,7 +39,7 @@ class TaskServiceViewSet(viewsets.ModelViewSet):
     destroy:
     Completely remove the task service from the coordinator.
     """
-    authentication_classes = (EgoAuthentication,)
+    authentication_classes = (Auth0Authentication, EgoAuthentication)
     permission_classes = (DevPermission,)
     lookup_field = 'kf_id'
     queryset = TaskService.objects.order_by('-created_at').all()

--- a/coordinator/authentication.py
+++ b/coordinator/authentication.py
@@ -1,5 +1,6 @@
 import datetime
 import jwt
+import json
 import re
 import textwrap
 import requests
@@ -95,6 +96,88 @@ class EgoAuthentication(authentication.BaseAuthentication):
         user = token['context']['user']
 
         return (user, None)
+
+
+class Auth0Authentication(authentication.BaseAuthentication):
+
+    @staticmethod
+    def _get_auth0_key():
+        """
+        Attempts to retrieve the ego public key from the cache. If it's not
+        there or is expired, fetch a new one from ego and store it back in the
+        cache.
+        """
+        key = cache.get(settings.CACHE_AUTH0_KEY, None)
+        # If key is not set in cache (or has timed out), get a new one
+        if key is None:
+            key = Auth0Authentication._get_key()
+            cache.set(settings.CACHE_AUTH0_KEY, key,
+                      settings.CACHE_AUTH0_TIMEOUT)
+        return key
+
+    @staticmethod
+    def _get_new_key():
+        """
+        Get a public key from Auth0's JWKS
+        Reformat the JWKS into a PEM format
+        """
+        resp = requests.get(settings.AUTH0_JWKS, timeout=10)
+        key = resp.json()['keys'][0]
+        public_key = jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key))
+        return public_key
+
+    def authenticate(self, request):
+        """
+        Attempt to authenticate if there is an `Authorization` header
+        with a token is prefixed with `Bearer `.
+
+        :returns: The JWT context if a valid JWT was in the header,
+            None otherwise.
+        :raises: AuthenticationFailed if the token is not valid
+        """
+        if settings.DEBUG:
+            return ({'roles': 'ADMIN'}, None)
+
+        token = request.META.get('HTTP_AUTHORIZATION')
+        if token is None:
+            header = request.META.get('headers')
+            # No headers
+            if header is None:
+                return ({}, None)
+            token = header.get('Authorization', None)
+        # No Authorization header
+        if token is None:
+            return ({}, None)
+        # Unexpected token type
+        if 'Bearer ' not in token:
+            return ({}, None)
+
+        token = token.split('Bearer ')[-1]
+
+        try:
+            public_key = Auth0Authentication._get_new_key()
+            token = jwt.decode(token, public_key, algorithms='RS256',
+                               options={'verify_aud': False})
+        except (TypeError, KeyError):
+            # If we had trouble getting JWKS
+            return None
+        except jwt.exceptions.DecodeError as err:
+            raise exceptions.AuthenticationFailed(
+                f'Problem authenticating request: {err}'
+            )
+        except jwt.exceptions.InvalidTokenError as err:
+            raise exceptions.AuthenticationFailed(
+                f'Token provided is not valid: {err}'
+            )
+
+        token['permissions'] = token['https://kidsfirstdrc.org/permissions']
+        token['groups'] = token['https://kidsfirstdrc.org/groups']
+        token['roles'] = token['https://kidsfirstdrc.org/roles']
+        del token['https://kidsfirstdrc.org/permissions']
+        del token['https://kidsfirstdrc.org/groups']
+        del token['https://kidsfirstdrc.org/roles']
+
+        return (token, None)
 
 
 def get_service_token():

--- a/coordinator/authentication.py
+++ b/coordinator/authentication.py
@@ -68,14 +68,14 @@ class EgoAuthentication(authentication.BaseAuthentication):
             header = request.META.get('headers')
             # No headers
             if header is None:
-                return ({}, None)
+                return None
             token = header.get('Authorization', None)
         # No Authorization header
         if token is None:
-            return ({}, None)
+            return None
         # Unexpected token type
         if 'Bearer ' not in token:
-            return ({}, None)
+            return None
 
         token = token.split('Bearer ')[-1]
 
@@ -85,13 +85,11 @@ class EgoAuthentication(authentication.BaseAuthentication):
             token = jwt.decode(token, public_key, algorithms='RS256',
                                options={'verify_aud': False})
         except jwt.exceptions.DecodeError as err:
-            raise exceptions.AuthenticationFailed(
-                f'Problem authenticating request: {err}'
-            )
+            logger.error(f'Problem authenticating request: {err}')
+            return None
         except jwt.exceptions.InvalidTokenError as err:
-            raise exceptions.AuthenticationFailed(
-                f'Token provided is not valid: {err}'
-            )
+            logger.error(f'Token provided is not valid: {err}')
+            return None
 
         user = token['context']['user']
 
@@ -143,14 +141,14 @@ class Auth0Authentication(authentication.BaseAuthentication):
             header = request.META.get('headers')
             # No headers
             if header is None:
-                return ({}, None)
+                return None
             token = header.get('Authorization', None)
         # No Authorization header
         if token is None:
-            return ({}, None)
+            return None
         # Unexpected token type
         if 'Bearer ' not in token:
-            return ({}, None)
+            return None
 
         token = token.split('Bearer ')[-1]
 
@@ -162,13 +160,11 @@ class Auth0Authentication(authentication.BaseAuthentication):
             # If we had trouble getting JWKS
             return None
         except jwt.exceptions.DecodeError as err:
-            raise exceptions.AuthenticationFailed(
-                f'Problem authenticating request: {err}'
-            )
+            logger.error(f'Problem authenticating request: {err}')
+            return None
         except jwt.exceptions.InvalidTokenError as err:
-            raise exceptions.AuthenticationFailed(
-                f'Token provided is not valid: {err}'
-            )
+            logger.error(f'Token provided is not valid: {err}')
+            return None
 
         token['permissions'] = token['https://kidsfirstdrc.org/permissions']
         token['groups'] = token['https://kidsfirstdrc.org/groups']

--- a/coordinator/permissions.py
+++ b/coordinator/permissions.py
@@ -1,4 +1,5 @@
 from rest_framework import permissions
+from django.contrib.auth.models import AnonymousUser
 
 
 class AdminPermission(permissions.BasePermission):
@@ -7,6 +8,10 @@ class AdminPermission(permissions.BasePermission):
     def has_permission(self, request, view):
         if request.method in permissions.SAFE_METHODS:
             return True
+
+        if isinstance(request.user, AnonymousUser):
+            return False
+
         if 'ADMIN' in roles:
             return True
 
@@ -21,12 +26,16 @@ class DevPermission(permissions.BasePermission):
     def has_permission(self, request, view):
         if request.method in permissions.SAFE_METHODS:
             return True
+
+        if request.method == 'POST' and request.path.endswith('health_checks'):
+            return True
+
+        if isinstance(request.user, AnonymousUser):
+            return False
+
         roles = request.user.get('roles', [])
 
         if 'ADMIN' in roles or 'DEV' in roles:
-            return True
-
-        if request.method == 'POST' and request.path.endswith('health_checks'):
             return True
 
 
@@ -45,6 +54,9 @@ class GroupPermission(permissions.BasePermission):
     def has_permission(self, request, view):
         if request.method in permissions.SAFE_METHODS:
             return True
+
+        if isinstance(request.user, AnonymousUser):
+            return False
 
         roles = request.user.get('roles', [])
         groups = request.user.get('groups', [])
@@ -69,6 +81,9 @@ class GroupPermission(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         if request.method in permissions.SAFE_METHODS:
             return True
+
+        if isinstance(request.user, AnonymousUser):
+            return False
 
         roles = request.user.get('roles', [])
         groups = request.user.get('groups', [])

--- a/coordinator/settings/development.py
+++ b/coordinator/settings/development.py
@@ -160,6 +160,12 @@ CACHE_EGO_TOKEN = 'EGO_SERVICE_TOKEN'
 # How often the Ego public key should be retrieved from ego, 1 day default
 CACHE_EGO_TIMEOUT = 86400
 
+AUTH0_JWKS = 'https://kids-first.auth0.com/.well-known/jwks.json'
+CACHE_AUTH0_KEY = 'AUTH0_PUBLIC_KEY'
+CACHE_AUTH0_TIMEOUT = 86400
+
+JWT_AUD = 'https://kf-release-coord.kidsfirstdrc.org'
+
 SNS_ARN = os.environ.get('SNS_ARN', None)
 
 DATASERVICE_URL = os.environ.get('DATASERVICE_URL', None)

--- a/coordinator/settings/production.py
+++ b/coordinator/settings/production.py
@@ -159,6 +159,12 @@ CACHE_EGO_TOKEN = 'EGO_SERVICE_TOKEN'
 # How often the Ego public key should be retrieved from ego, 1 day default
 CACHE_EGO_TIMEOUT = 86400
 
+AUTH0_JWKS = 'https://kids-first.auth0.com/.well-known/jwks.json'
+CACHE_AUTH0_KEY = 'AUTH0_PUBLIC_KEY'
+CACHE_AUTH0_TIMEOUT = 86400
+
+JWT_AUD = 'https://kf-release-coord.kidsfirstdrc.org'
+
 SNS_ARN = os.environ.get('SNS_ARN', None)
 
 DATASERVICE_URL = os.environ.get('DATASERVICE_URL', None)

--- a/coordinator/settings/testing.py
+++ b/coordinator/settings/testing.py
@@ -129,6 +129,12 @@ CACHE_EGO_TOKEN = 'EGO_SERVICE_TOKEN'
 # How often the Ego public key should be retrieved from ego, 1 day default
 CACHE_EGO_TIMEOUT = 86400
 
+AUTH0_JWKS = 'https://kids-first.auth0.com/.well-known/jwks.json'
+CACHE_AUTH0_KEY = 'AUTH0_PUBLIC_KEY'
+CACHE_AUTH0_TIMEOUT = 86400
+
+JWT_AUD = 'https://kf-release-coord.kidsfirstdrc.org'
+
 SNS_ARN = None
 
 DATASERVICE_URL = 'http://dataservice'

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -19,10 +19,10 @@ def test_invalid_jwt(client, db, fakes):
                        headers={'Authorization': 'Bearer INVALID'})
 
     assert resp.status_code == 403
-    assert resp.json()['detail'].startswith('Problem authenticating request')
+    assert resp.json()['detail'].startswith('Authentication credentials were')
 
 
-def test_invalid_jwt(client, db, token):
+def test_invalid_jwt_signature(client, db, token):
     """
     Any endpoint will try to authenticate if there is an Authorization
     header that is prefixed with `Bearer `.
@@ -38,7 +38,7 @@ def test_invalid_jwt(client, db, token):
                        headers={'Authorization': f'Bearer {str(encoded)}'})
 
     assert resp.status_code == 403
-    assert resp.json()['detail'].startswith('Problem authenticating request')
+    assert resp.json()['detail'].startswith('Authentication credentials were')
 
 
 def test_my_studies(user_client, db, fakes):


### PR DESCRIPTION
Adds authentication class for Auth0 token validation. This relies on the `accessToken` being sent to the coordinator to contain these claims:
- `https://kidsfirstdrc.org/groups`
- `https://kidsfirstdrc.org/roles`
- `https://kidsfirstdrc.org/permissions`

These will be translated to ego equivalents.

Future refactoring should be made to make permission checks consistent by returning actual `User` models from the authentication classes.