### PR TITLE
♻️ Refactor for getting db host from environment

### DIFF
--- a/bin/dev_entrypoint.sh
+++ b/bin/dev_entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/ash
-/app/bin/wait-for-pg.sh pg
+/app/bin/wait-for-pg.sh ${PG_HOST:-pg}
 python /app/manage.py migrate
 python /app/manage.py runserver 0.0.0.0:5000


### PR DESCRIPTION
Get database host from the environment, if not specified, default to `pg`

closes #163