### PR TITLE
👷 Update gh-pages build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,9 @@
 version: 2
 jobs:
   build:
+    branches:
+      ignore:
+        - gh-pages
     docker:
       - image: circleci/python:3.6.1
       - image: postgres:9.5
@@ -66,11 +69,11 @@ jobs:
                 git checkout -b gh-pages
                 git fetch origin gh-pages
                 git reset --hard origin/gh-pages
-                rm -r ./*
+                GLOBIGNORE=.git rm -rf ./*
                 mv ../staged/* ./
                 git add -A .
                 git commit --allow-empty -m ":recycle: Update docs site"
-                git push -q https://${GITHUB_TOKEN}@github.com/kids-first/kf-api-study-creator.git
+                git push -q https://${GITHUB_TOKEN}@github.com/kids-first/kf-api-release-coordinator.git
             fi
 
       - store_artifacts:


### PR DESCRIPTION
Removes all but the .git directory when clearing files for the `gh-pages` branch.
Ignores CI builds for the `gh-pages` branch.