### PR TITLE
⬆️ Bump requests version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ base32-crockford==0.3.0
 django-rq==1.3.0
 rq==0.13.0
 redis==3.2.0
-drf-yasg==1.6.1
+drf-yasg==1.16.1
 PyJWT==1.6.4
 cryptography==2.3.0
 django-cors-headers==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,7 @@ django-filter==2.1.0
 djangorestframework==3.9.2
 gunicorn==19.7.1
 psycopg2==2.7.4
-requests==2.20.0
-urllib3==1.25.2
+requests==2.22.0
 base32-crockford==0.3.0
 django-rq==1.3.0
 rq==0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ django-fsm==2.6.0
 semantic-version==2.6.0
 drf-nested-routers==0.90.2
 boto3==1.9.112
+packaging==19.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ django-rq==1.3.0
 rq==0.13.0
 redis==3.2.0
 drf-yasg==1.16.1
+ruamel.yaml>=0.15.34,<0.16.0
 PyJWT==1.6.4
 cryptography==2.3.0
 django-cors-headers==2.2.0


### PR DESCRIPTION
Bumps requests and removes the hard dependency on urllib3 which was
causing version-incompatabilty issues with requests.