### PR TITLE
🐛 Don't allow tasks to be deleted

### DIFF
--- a/coordinator/api/views/task.py
+++ b/coordinator/api/views/task.py
@@ -37,6 +37,7 @@ class TaskViewSet(viewsets.ModelViewSet):
     serializer_class = TaskSerializer
     filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
     filter_class = TaskFilter
+    http_method_names = ["get", "post", "head", "put", "patch"]
 
     def partial_update(self, request, kf_id=None):
         """

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -111,3 +111,11 @@ def test_status_check(client, transactional_db, task, worker, mock_ego):
         # worker.work(burst=True)
         # release = t.release
         # assert release.state == 'canceling'
+
+
+def test_no_deletion(db, admin_client, task):
+    """ Check that tasks cannot be deleted """
+    assert Task.objects.count() == 1
+    resp = admin_client.delete(f"{BASE_URL}/tasks/{task['kf_id']}")
+    assert resp.status_code == 405
+    assert Task.objects.count() == 1


### PR DESCRIPTION
Disables the delete action on tasks so that they may not be deleted.

Fixes #180 