### PR TITLE
♻️ Only allow admins to create tasks directly

### DIFF
--- a/coordinator/api/views/task.py
+++ b/coordinator/api/views/task.py
@@ -3,6 +3,9 @@ from rest_framework import viewsets
 import django_filters.rest_framework
 from rest_framework.decorators import action
 from rest_framework.response import Response
+
+from coordinator.authentication import Auth0Authentication, EgoAuthentication
+from coordinator.permissions import AdminPermission
 from coordinator.tasks import status_check, cancel_release
 from coordinator.api.models import Task
 from coordinator.api.serializers import TaskSerializer
@@ -32,6 +35,8 @@ class TaskViewSet(viewsets.ModelViewSet):
     destroy:
     Removes a task entirely
     """
+    authentication_classes = (Auth0Authentication, EgoAuthentication,)
+    permission_classes = (AdminPermission,)
     lookup_field = 'kf_id'
     queryset = Task.objects.order_by('-created_at').all()
     serializer_class = TaskSerializer

--- a/coordinator/permissions.py
+++ b/coordinator/permissions.py
@@ -12,6 +12,8 @@ class AdminPermission(permissions.BasePermission):
         if isinstance(request.user, AnonymousUser):
             return False
 
+        roles = request.user.get('roles', [])
+
         if 'ADMIN' in roles:
             return True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,17 @@ def user_client(token):
 
 
 @pytest.yield_fixture
+def test_client(admin_client, dev_client, user_client, client):
+    """ Returns a client for the specified user_type """
+    yield lambda user_type: {
+        "admin": admin_client,
+        "dev": dev_client,
+        "user": user_client,
+        "anon": client,
+    }[user_type]
+
+
+@pytest.yield_fixture
 def worker():
     # Clear queue
     q = django_rq.get_queue()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -111,3 +111,22 @@ def test_status_check(client, transactional_db, task, worker, mock_ego):
         # worker.work(burst=True)
         # release = t.release
         # assert release.state == 'canceling'
+
+
+@pytest.mark.parametrize(
+    "user_type,expected_status",
+    [("admin", 201), ("dev", 403), ("user", 403), ("anon", 403)],
+)
+def test_task_creation(
+    db, test_client, release, task_service, user_type, expected_status
+):
+    """ Test that only admins may create tasks """
+    client = test_client(user_type)
+    resp = client.post(
+        f"{BASE_URL}/tasks",
+        data={
+            "release": f"{BASE_URL}/releases/{release['kf_id']}",
+            "task_service": f"{BASE_URL}/task-services/{task_service['kf_id']}",
+        },
+    )
+    assert resp.status_code == expected_status


### PR DESCRIPTION
This makes it so that only admins may directly create tasks.

Fixes #177 