### PR TITLE
🏭 Add fakedata command

### DIFF
--- a/bin/dev_entrypoint.sh
+++ b/bin/dev_entrypoint.sh
@@ -1,4 +1,15 @@
 #!/bin/ash
 /app/bin/wait-for-pg.sh ${PG_HOST:-pg}
+
+case $PRELOAD_DATA in
+    "FAKE")
+        echo "Will create fake data"
+        /app/manage.py fakedata
+        ;;
+    *)
+        echo "Will not pre-populate database"
+        ;;
+esac
+
 python /app/manage.py migrate
 python /app/manage.py runserver 0.0.0.0:5000

--- a/coordinator/api/management/commands/fakedata.py
+++ b/coordinator/api/management/commands/fakedata.py
@@ -1,0 +1,10 @@
+from django.core.management.base import BaseCommand
+from coordinator.api.factories.release import ReleaseFactory
+
+
+class Command(BaseCommand):
+    help = "Pre-populate the database with fake data"
+
+    def handle(self, *args, **options):
+        ReleaseFactory.create_batch(100)
+        self.stdout.write(self.style.SUCCESS("Created releases"))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - REDIS_HOST=redis
       - REDIS_PORT=6379
       - DJANGO_SETTINGS_MODULE=${DJANGO_SETTINGS_MODULE:-coordinator.settings.testing}
+      - PRELOAD_DATA=FAKE
     depends_on:
       - pg
       - redis


### PR DESCRIPTION
This adds a command that will prepopulate the database with a number of releases and their dependent objects.
It will be run by default when running in `docker-compose` but may be disabled through the `PRELOAD_DATA` variable.