### PR TITLE
✨ Add queries for task services

### DIFF
--- a/coordinator/api/factories/task_service.py
+++ b/coordinator/api/factories/task_service.py
@@ -6,7 +6,9 @@ from coordinator.api.models.taskservice import TaskService
 class TaskServiceFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = TaskService
+        django_get_or_create = ("kf_id",)
 
+    kf_id = factory.Sequence(lambda n: f"SD_{(n%3):08}")
     name = factory.Faker("bs")
     author = factory.Faker("name")
     description = factory.Faker("bs")

--- a/coordinator/graphql/schema.py
+++ b/coordinator/graphql/schema.py
@@ -4,9 +4,10 @@ from graphene_django.filter import DjangoFilterConnectionField
 
 from .releases import Query as ReleaseQuery
 from .tasks import Query as TaskQuery
+from .task_services import Query as TaskServiceQuery
 
 
-class Query(ObjectType, ReleaseQuery, TaskQuery):
+class Query(ObjectType, ReleaseQuery, TaskQuery, TaskServiceQuery):
     pass
 
 

--- a/coordinator/graphql/task_services.py
+++ b/coordinator/graphql/task_services.py
@@ -1,0 +1,50 @@
+from django_filters import CharFilter, FilterSet, NumberFilter, OrderingFilter
+from graphene import relay, ObjectType, String
+from graphene_django.types import DjangoObjectType
+from graphene_django.filter import DjangoFilterConnectionField
+
+from coordinator.api.models.taskservice import TaskService
+
+
+class TaskServiceNode(DjangoObjectType):
+    """ A task service in the TaskService Coordinator """
+
+    health_status = String(
+        resolver=lambda obj, _: obj.health_status,
+        description="Current status of the task service",
+    )
+
+    class Meta:
+        model = TaskService
+        interfaces = (relay.Node,)
+
+
+class TaskServiceFilter(FilterSet):
+    name_contains = CharFilter(field_name="name", lookup_expr="icontains")
+    created_before = NumberFilter(field_name="created_at", lookup_expr="lt")
+    created_after = NumberFilter(field_name="created_at", lookup_expr="gt")
+    order_by = OrderingFilter(fields=("created_at",))
+
+    class Meta:
+        model = TaskService
+        fields = ["author", "name", "url", "description", "enabled"]
+
+
+class Query:
+    task_service = relay.Node.Field(
+        TaskServiceNode, description="Retrieve a single task service"
+    )
+    all_task_services = DjangoFilterConnectionField(
+        TaskServiceNode,
+        filterset_class=TaskServiceFilter,
+        description="Get all task services from the Coordinator",
+    )
+
+    def resolve_all_task_services(self, info, **kwargs):
+        user = info.context.user
+        if hasattr(user, "roles") and (
+            "ADMIN" in user.roles or "DEV" in user.roles
+        ):
+            return TaskService.objects.all()
+
+        return TaskService.objects.none()

--- a/tests/graphql/task_services/test_task_service_queries.py
+++ b/tests/graphql/task_services/test_task_service_queries.py
@@ -1,0 +1,72 @@
+import pytest
+from coordinator.api.models import Study, Task
+from coordinator.api.factories.release import ReleaseFactory
+
+
+ALL_TASK_SERVICES = """
+query (
+    $name: String,
+    $url: String,
+    $author: String,
+    $createdBefore: Float,
+    $createdAfter: Float,
+    $orderBy:String
+) {
+    allTaskServices(
+        name: $name,
+        url: $url,
+        author: $author,
+        createdBefore: $createdBefore,
+        createdAfter: $createdAfter,
+        orderBy: $orderBy
+    ) {
+        edges {
+            node {
+                id
+                kfId
+                uuid
+                author
+                name
+                description
+                url
+                enabled
+                createdAt
+            }
+        }
+    }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "user_type,expected",
+    [
+        ("admin", lambda: 3),
+        ("dev", lambda: 3),
+        ("user", lambda: 0),
+        ("anon", lambda: 0),
+    ],
+)
+def test_list_all_tasks_permissions(db, test_client, user_type, expected):
+    """
+    ADMIN - Can query all task services
+    DEV - Can query all task services
+    USER - Cannot query any task services
+    anonomous - Cannot query any task services
+
+    The TaskServiceFactory maxes at 3 unique task services, so we should never
+    expect more than than.
+    """
+    study = Study(kf_id="SD_00000001")
+    study.save()
+
+    releases = ReleaseFactory.create_batch(10, state="staged")
+    releases = ReleaseFactory.create_batch(10, state="published")
+    releases = ReleaseFactory.create_batch(
+        10, state="staging", studies=[study]
+    )
+
+    client = test_client(user_type)
+    resp = client.post("/graphql", data={"query": ALL_TASK_SERVICES})
+    # Test that the correct number of releases are returned
+    assert len(resp.json()["data"]["allTaskServices"]["edges"]) == expected()


### PR DESCRIPTION
Adds `allTaskServices` and `taskService` queries to get task services using graphql.

Closes #197 