### PR TITLE
✨ Add graphql query for release notes

### DIFF
--- a/coordinator/api/factories/release_note.py
+++ b/coordinator/api/factories/release_note.py
@@ -9,8 +9,8 @@ class ReleaseNoteFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = ReleaseNote
 
-    kf_id = "RN_00000000"
+    kf_id = factory.Sequence(lambda n: f"RN_{n:08}")
     author = factory.Faker("name")
     description = factory.Faker("bs")
+    release = factory.SubFactory(ReleaseFactory)
     study = factory.SubFactory(StudyFactory)
-    release = factory.SubFactory(ReleaseFactory, kf_id="RE_00000000")

--- a/coordinator/graphql/release_notes.py
+++ b/coordinator/graphql/release_notes.py
@@ -1,0 +1,57 @@
+from django_filters import CharFilter, FilterSet, NumberFilter, OrderingFilter
+from graphene import relay, ObjectType
+from graphene_django.types import DjangoObjectType
+from graphene_django.filter import DjangoFilterConnectionField
+
+from coordinator.api.models.release_note import ReleaseNote
+
+
+class ReleaseNoteNode(DjangoObjectType):
+    """ A release note for a release or a study within a release """
+
+    class Meta:
+        model = ReleaseNote
+        filter_fields = {}
+        interfaces = (relay.Node,)
+
+
+class ReleaseNoteFilter(FilterSet):
+    created_before = NumberFilter(field_name="created_at", lookup_expr="lt")
+    created_after = NumberFilter(field_name="created_at", lookup_expr="gt")
+    order_by = OrderingFilter(fields=("created_at",))
+
+    class Meta:
+        model = ReleaseNote
+        fields = ["kf_id", "author", "release", "study"]
+
+
+class Query:
+    event = relay.Node.Field(
+        ReleaseNoteNode, description="Retrieve a single release note"
+    )
+    all_release_notes = DjangoFilterConnectionField(
+        ReleaseNoteNode,
+        filterset_class=ReleaseNoteFilter,
+        description="Get all release notes from the Coordinator",
+    )
+
+    def resolve_all_release_notes(self, info, **kwargs):
+        """
+        ADMIN - Return all release notes
+        DEV - Return all release notes
+        USER - Return release notes for all published releases and releases
+            which have studies that the user is a member of.
+        ANON - Return release notes for all published releases
+        """
+        user = info.context.user
+        if hasattr(user, "roles") and (
+            "ADMIN" in user.roles or "DEV" in user.roles
+        ):
+            return ReleaseNote.objects.all()
+
+        if hasattr(user, "groups") and len(user.groups) > 0:
+            return ReleaseNote.objects.filter(
+                release__studies__kf_id__in=user.groups
+            ) | ReleaseNote.objects.filter(release__state="published")
+
+        return ReleaseNote.objects.filter(release__state="published").all()

--- a/coordinator/graphql/schema.py
+++ b/coordinator/graphql/schema.py
@@ -6,9 +6,17 @@ from .releases import Query as ReleaseQuery
 from .tasks import Query as TaskQuery
 from .task_services import Query as TaskServiceQuery
 from .events import Query as EventQuery
+from .release_notes import Query as ReleaseNoteQuery
 
 
-class Query(ObjectType, ReleaseQuery, TaskQuery, TaskServiceQuery, EventQuery):
+class Query(
+    ObjectType,
+    ReleaseQuery,
+    TaskQuery,
+    TaskServiceQuery,
+    EventQuery,
+    ReleaseNoteQuery,
+):
     pass
 
 

--- a/tests/graphql/release_notes/test_release_note_queries.py
+++ b/tests/graphql/release_notes/test_release_note_queries.py
@@ -1,0 +1,66 @@
+import pytest
+from coordinator.api.models import ReleaseNote
+from coordinator.api.factories.release import ReleaseFactory
+from coordinator.api.factories.release_note import ReleaseNoteFactory
+from coordinator.api.factories.study import StudyFactory
+
+
+ALL_RELEASE_NOTES = """
+query (
+    $author: String,
+    $study: ID,
+    $release: ID,
+    $createdBefore: Float,
+    $createdAfter: Float,
+    $orderBy:String
+) {
+    allReleaseNotes(
+        author: $author,
+        study: $study,
+        release: $release,
+        createdBefore: $createdBefore,
+        createdAfter: $createdAfter,
+        orderBy: $orderBy
+    ) {
+        edges {
+            node {
+                id
+                kfId
+                uuid
+                author
+                description
+                createdAt
+            }
+        }
+    }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "user_type,expected",
+    [("admin", 30), ("dev", 30), ("user", 20), ("anon", 10)],
+)
+def test_list_all_permissions(db, test_client, user_type, expected):
+    """
+    ADMIN - Can query all release notes
+    DEV - Can query all release notes
+    USER - Can query release notes from published releases and releases that
+        their studies are in
+    ANON - Can only query release notes from published release notes
+    """
+    study = StudyFactory(kf_id="SD_00000001")
+    release_study = ReleaseFactory(state="staging", studies=[study])
+    release_staged = ReleaseFactory(state="staged")
+    release_pub = ReleaseFactory(state="published")
+
+    release_notes = ReleaseNoteFactory.create_batch(10, release=release_staged)
+    releases_notes = ReleaseNoteFactory.create_batch(10, release=release_pub)
+    releases_notes = ReleaseNoteFactory.create_batch(
+        10, release=release_study, study=study
+    )
+
+    client = test_client(user_type)
+    resp = client.post("/graphql", data={"query": ALL_RELEASE_NOTES})
+    # Test that the correct number of release notes are returned
+    assert len(resp.json()["data"]["allReleaseNotes"]["edges"]) == expected


### PR DESCRIPTION
Adds an `allReleaseNotes` query to get release notes via the graphql api.

Closes #198 