### PR TITLE
⬆️ Upgrade semantic-version package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ PyJWT==1.6.4
 cryptography==2.3.0
 django-cors-headers==2.2.0
 django-fsm==2.6.0
-semantic-version==2.6.0
+semantic-version==2.8.2
 drf-nested-routers==0.90.2
 boto3==1.9.112
 packaging==19.1


### PR DESCRIPTION
This fixes the many `RemovedInDjango30Warning: Remove the context parameter from VersionField.from_db_value(). Support for it will be removed in Django 3.0.` warnings that occur during testing.