### PR TITLE
✨ Graphql release mutations

### DIFF
--- a/coordinator/graphql/releases.py
+++ b/coordinator/graphql/releases.py
@@ -1,11 +1,12 @@
 from django_filters import CharFilter, FilterSet, NumberFilter, OrderingFilter
 import graphene
 import django_rq
+import django_fsm
 from graphql import GraphQLError
 from graphql_relay import from_global_id
 from graphene_django.types import DjangoObjectType
 from graphene_django.filter import DjangoFilterConnectionField
-from coordinator.tasks import init_release, cancel_release
+from coordinator.tasks import init_release, cancel_release, publish_release
 
 from coordinator.api.models.release import Release
 
@@ -106,6 +107,44 @@ class CancelRelease(graphene.Mutation):
         return CancelRelease(release=release)
 
 
+class PublishRelease(graphene.Mutation):
+    class Arguments:
+        release = graphene.ID(required=True)
+
+    release = graphene.Field(ReleaseNode)
+
+    @staticmethod
+    def mutate(root, info, release):
+        """
+        Publish a staged release.
+
+        Only releases that have made it to the staged state may be published
+        by an administrator.
+        """
+        user = info.context.user
+        if not hasattr(user, "roles") or "ADMIN" not in user.roles:
+            raise GraphQLError("Not authenticated to publish a release.")
+
+        _, kf_id = from_global_id(release)
+
+        try:
+            release = Release.objects.get(kf_id=kf_id)
+        except Release.DoesNotExist:
+            raise GraphQLError("The release was not found.")
+
+        try:
+            release.publish()
+            release.save()
+        except django_fsm.TransitionNotAllowed:
+            raise GraphQLError(
+                f"The release in state {release.state} may not be published."
+            )
+
+        django_rq.enqueue(publish_release, release.kf_id)
+
+        return CancelRelease(release=release)
+
+
 class Query:
     release = graphene.relay.Node.Field(
         ReleaseNode, description="Retrieve a single release"
@@ -129,3 +168,4 @@ class Query:
 class Mutation:
     start_release = StartRelease.Field(description="Start a new release")
     cancel_release = CancelRelease.Field(description="Cancel a release")
+    publish_release = PublishRelease.Field(description="Publish a release")

--- a/coordinator/graphql/schema.py
+++ b/coordinator/graphql/schema.py
@@ -2,7 +2,7 @@ from graphene import relay, ObjectType, Schema
 from graphene_django.types import DjangoObjectType
 from graphene_django.filter import DjangoFilterConnectionField
 
-from .releases import Query as ReleaseQuery
+from .releases import Query as ReleaseQuery, Mutation as ReleaseMutation
 from .tasks import Query as TaskQuery
 from .task_services import Query as TaskServiceQuery
 from .events import Query as EventQuery
@@ -22,4 +22,8 @@ class Query(
     pass
 
 
-schema = Schema(query=Query)
+class Mutation(ObjectType, ReleaseMutation):
+    pass
+
+
+schema = Schema(query=Query, mutation=Mutation)

--- a/tests/graphql/releases/test_cancel_release.py
+++ b/tests/graphql/releases/test_cancel_release.py
@@ -1,0 +1,100 @@
+import pytest
+from graphql_relay.node.node import to_global_id
+from coordinator.api.models import Release
+from coordinator.api.factories.release import ReleaseFactory
+
+
+CANCEL_RELEASE = """
+mutation ($release: ID!) {
+    cancelRelease(release: $release) {
+        release {
+            id
+            kfId
+            uuid
+            author
+            name
+            description
+            state
+            tags
+            version
+            isMajor
+            createdAt
+            studies {
+                edges {
+                    node {
+                        id
+                        kfId
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "user_type,expected",
+    [("admin", True), ("dev", True), ("user", False), ("anon", False)],
+)
+def test_cancel_permissions(db, test_client, user_type, expected):
+    """
+    ADMIN - Can cancel a release
+    DEV - Can cancel a release
+    USER - May not cancel relases
+    anonomous - May not cancel releases
+    """
+    release = ReleaseFactory()
+    variables = {"release": to_global_id("ReleaseNode", release.kf_id)}
+
+    client = test_client(user_type)
+    resp = client.post(
+        "/graphql",
+        format="json",
+        data={"query": CANCEL_RELEASE, "variables": variables},
+    )
+
+    if expected:
+        assert "kfId" in resp.json()["data"]["cancelRelease"]["release"]
+    else:
+        assert "errors" in resp.json()
+        assert "Not authenticated" in resp.json()["errors"][0]["message"]
+
+
+@pytest.mark.parametrize(
+    "state,allowed",
+    [
+        ("waiting", True),
+        ("initializing", True),
+        ("running", True),
+        ("staged", True),
+        ("canceling", True),
+        ("canceled", False),
+        ("publishing", True),
+        ("published", False),
+    ],
+)
+def test_cancel_release_from_state(db, admin_client, mocker, state, allowed):
+    """
+    Test that a release is canceled correctly from any state
+    """
+    mock_rq = mocker.patch("coordinator.graphql.releases.django_rq")
+
+    release = ReleaseFactory(state=state)
+    variables = {"release": to_global_id("ReleaseNode", release.kf_id)}
+
+    resp = admin_client.post(
+        "/graphql",
+        format="json",
+        data={"query": CANCEL_RELEASE, "variables": variables},
+    )
+
+    if allowed:
+        # Check that the release task was queued
+        assert mock_rq.enqueue.call_count == 1
+        assert (
+            resp.json()["data"]["cancelRelease"]["release"]["state"]
+            == "canceling"
+        )
+    else:
+        assert "errors" in resp.json()

--- a/tests/graphql/releases/test_create_release.py
+++ b/tests/graphql/releases/test_create_release.py
@@ -1,0 +1,102 @@
+import pytest
+from graphql_relay.node.node import to_global_id
+from coordinator.api.models import Release
+from coordinator.api.factories.study import StudyFactory
+
+
+CREATE_RELEASE = """
+mutation ($input: ReleaseInput!) {
+    startRelease(input: $input) {
+        release {
+            id
+            kfId
+            uuid
+            author
+            name
+            description
+            state
+            tags
+            version
+            isMajor
+            createdAt
+            studies {
+                edges {
+                    node {
+                        id
+                        kfId
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "user_type,expected",
+    [("admin", True), ("dev", True), ("user", False), ("anon", False)],
+)
+def test_start_release_permissions(db, test_client, user_type, expected):
+    """
+    ADMIN - Can create a new release
+    DEV - Can create a new release
+    USER - May not create relases
+    anonomous - May not create releases
+    """
+    studies = StudyFactory.create_batch(3)
+    study_ids = [to_global_id("StudyNode", study.kf_id) for study in studies]
+
+    variables = {
+        "input": {
+            "name": "Test Release",
+            "isMajor": False,
+            "studies": study_ids,
+        }
+    }
+
+    client = test_client(user_type)
+    resp = client.post(
+        "/graphql",
+        format="json",
+        data={"query": CREATE_RELEASE, "variables": variables},
+    )
+
+    if expected:
+        assert "kfId" in resp.json()["data"]["startRelease"]["release"]
+    else:
+        assert "errors" in resp.json()
+
+
+def test_create_release(db, admin_client, mocker):
+    """
+    Test that releases are created correctly.
+    """
+    mock_rq = mocker.patch("coordinator.graphql.releases.django_rq")
+
+    studies = StudyFactory.create_batch(3)
+    study_ids = [to_global_id("StudyNode", study.kf_id) for study in studies]
+
+    variables = {
+        "input": {
+            "name": "Test Release",
+            "isMajor": False,
+            "studies": study_ids,
+        }
+    }
+
+    resp = admin_client.post(
+        "/graphql",
+        format="json",
+        data={"query": CREATE_RELEASE, "variables": variables},
+    )
+
+    release = resp.json()["data"]["startRelease"]["release"]
+    assert release["kfId"] == Release.objects.first().kf_id
+    assert release["name"] == "Test Release"
+    assert release["isMajor"] is False
+    assert release["author"] == "bobby"
+    assert len(release["studies"]["edges"]) == 3
+
+    # Check that the release task was queued
+    assert mock_rq.enqueue.call_count == 1

--- a/tests/graphql/releases/test_publish_release.py
+++ b/tests/graphql/releases/test_publish_release.py
@@ -1,0 +1,100 @@
+import pytest
+from graphql_relay.node.node import to_global_id
+from coordinator.api.models import Release
+from coordinator.api.factories.release import ReleaseFactory
+
+
+PUBLISH_RELEASE = """
+mutation ($release: ID!) {
+    publishRelease(release: $release) {
+        release {
+            id
+            kfId
+            uuid
+            author
+            name
+            description
+            state
+            tags
+            version
+            isMajor
+            createdAt
+            studies {
+                edges {
+                    node {
+                        id
+                        kfId
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "user_type,expected",
+    [("admin", True), ("dev", False), ("user", False), ("anon", False)],
+)
+def test_publish_permissions(db, test_client, user_type, expected):
+    """
+    ADMIN - Can publish a release
+    DEV - May not publish a release
+    USER - May not publish a relase
+    anonomous - May not publish a release
+    """
+    release = ReleaseFactory(state="staged")
+    variables = {"release": to_global_id("ReleaseNode", release.kf_id)}
+
+    client = test_client(user_type)
+    resp = client.post(
+        "/graphql",
+        format="json",
+        data={"query": PUBLISH_RELEASE, "variables": variables},
+    )
+
+    if expected:
+        assert "kfId" in resp.json()["data"]["publishRelease"]["release"]
+    else:
+        assert "errors" in resp.json()
+        assert "Not authenticated" in resp.json()["errors"][0]["message"]
+
+
+@pytest.mark.parametrize(
+    "state,allowed",
+    [
+        ("waiting", False),
+        ("initializing", False),
+        ("running", False),
+        ("staged", True),
+        ("canceling", False),
+        ("canceled", False),
+        ("publishing", False),
+        ("published", False),
+    ],
+)
+def test_publish_release_from_state(db, admin_client, mocker, state, allowed):
+    """
+    Test that a release may only be published from the staged state.
+    """
+    mock_rq = mocker.patch("coordinator.graphql.releases.django_rq")
+
+    release = ReleaseFactory(state=state)
+    variables = {"release": to_global_id("ReleaseNode", release.kf_id)}
+
+    resp = admin_client.post(
+        "/graphql",
+        format="json",
+        data={"query": PUBLISH_RELEASE, "variables": variables},
+    )
+
+    if allowed:
+        # Check that the release task was queued
+        assert mock_rq.enqueue.call_count == 1
+        assert (
+            resp.json()["data"]["publishRelease"]["release"]["state"]
+            == "publishing"
+        )
+    else:
+        assert "errors" in resp.json()


### PR DESCRIPTION
Adds mutations for creating, publishing, and canceling releases.

Closes #201 
Closes #202 
Closes #203 