### PR TITLE
✨ Add syncStudies mutation

### DIFF
--- a/coordinator/dataservice.py
+++ b/coordinator/dataservice.py
@@ -1,0 +1,49 @@
+import requests
+from django.conf import settings
+from coordinator.api.models import Study
+
+
+def sync():
+    if not settings.DATASERVICE_URL:
+        return
+
+    resp = requests.get(settings.DATASERVICE_URL + "/studies?limit=100")
+    print(resp.status_code)
+    resp.raise_for_status()
+
+    studies = Study.objects.all()
+    new = 0
+    deleted = 0
+
+    for study in resp.json()["results"]:
+        try:
+            s = Study.objects.get(kf_id=study["kf_id"])
+        # We don't know about the study, create it
+        except Study.DoesNotExist:
+            s = Study(
+                kf_id=study["kf_id"],
+                name=study["name"],
+                visible=study["visible"],
+                created_at=study["created_at"],
+            )
+            s.save()
+            new += 1
+            continue
+
+        # Check for updated fields
+        for field in ["name", "visible"]:
+            if getattr(s, field) != study[field]:
+                setattr(s, field, study[field])
+        s.save()
+
+    # Check if any studies were deleted from the dataservice
+    coord_studies = set(s.kf_id for s in studies)
+    ds_studies = set(s["kf_id"] for s in resp.json()["results"])
+    missing_studies = coord_studies - ds_studies
+    deleted = len(missing_studies)
+    for study in missing_studies:
+        s = Study.objects.get(kf_id=study)
+        s.deleted = True
+        s.save()
+
+    return new, deleted

--- a/coordinator/graphql/schema.py
+++ b/coordinator/graphql/schema.py
@@ -10,7 +10,7 @@ from .task_services import (
 )
 from .events import Query as EventQuery
 from .release_notes import Query as ReleaseNoteQuery
-from .studies import Query as StudyQuery
+from .studies import Query as StudyQuery, Mutation as StudyMutation
 
 
 class Query(
@@ -25,7 +25,9 @@ class Query(
     pass
 
 
-class Mutation(ObjectType, ReleaseMutation, TaskServiceMutation):
+class Mutation(
+    ObjectType, ReleaseMutation, TaskServiceMutation, StudyMutation
+):
     pass
 
 

--- a/tests/graphql/studies/test_study_sync.py
+++ b/tests/graphql/studies/test_study_sync.py
@@ -1,0 +1,46 @@
+import pytest
+
+
+SYNC_STUDIES = """
+mutation {
+    syncStudies {
+    new {
+      edges {
+        node {
+          id
+          kfId
+        }
+      }
+    }
+    deleted {
+      edges {
+        node {
+          id
+          kfId
+        }
+      }
+    }
+  }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "user_type,expected",
+    [("admin", True), ("dev", True), ("user", False), ("anon", False)],
+)
+def test_sync_permissions(db, test_client, mocker, user_type, expected):
+    """
+    ADMIN - Can sync studies
+    DEV - Can sync studies
+    USER - Can not sync studies
+    anonomous - Can not sync studies
+    """
+    mock_sync = mocker.patch("coordinator.graphql.studies.sync")
+    mock_sync.return_value = [], []
+
+    client = test_client(user_type)
+    resp = client.post("/graphql", data={"query": SYNC_STUDIES})
+
+    assert "errors" in resp.json() if not expected else "data" in resp.json()
+    assert mock_sync.call_count == 1 if expected else mock_sync.call_count == 0


### PR DESCRIPTION
Adds syncStudies mutation and abstracts the sync functionality so that it may be shared between the rest and graphQL apis.

Closes #225 