### PR TITLE
🐛 Fix task events

### DIFF
--- a/coordinator/authentication.py
+++ b/coordinator/authentication.py
@@ -17,16 +17,18 @@ logger.setLevel(logging.INFO)
 
 def headers():
     """ Construct headers for requests to task services """
-    headers = {
-        "Authorization": "Bearer "
-        + cache.get_or_set(
-            settings.CACHE_AUTH0_SERVICE_KEY,
-            get_service_token,
-            settings.CACHE_AUTH0_TIMEOUT,
-        )
-    }
-    headers.update(settings.REQUESTS_HEADERS)
-    return headers
+    token = cache.get_or_set(
+        settings.CACHE_AUTH0_SERVICE_KEY,
+        get_service_token,
+        settings.CACHE_AUTH0_TIMEOUT,
+    )
+
+    if token:
+        headers = {"Authorization": "Bearer " + token}
+        headers.update(settings.REQUESTS_HEADERS)
+        return headers
+    else:
+        return {}
 
 
 def get_service_token():

--- a/coordinator/tasks.py
+++ b/coordinator/tasks.py
@@ -171,7 +171,7 @@ def start_release(release_id):
                 message=f"request to start task failed: {err}",
                 release=release,
                 task=task,
-                task_service=service,
+                task_service=task.task_service,
             )
             ev.save()
 
@@ -241,7 +241,7 @@ def publish_release(release_id):
                 message=f"request to publish task failed: {err}",
                 release=release,
                 task=task,
-                task_service=service,
+                task_service=task_service,
             )
             ev.save()
 


### PR DESCRIPTION
Returns empty header if a service token failed to be retrieved from auth0 and uses correct reference to task service when creating an event.