### PR TITLE
🐛 Don't change to publishing state immediately

### DIFF
--- a/coordinator/graphql/releases.py
+++ b/coordinator/graphql/releases.py
@@ -132,10 +132,8 @@ class PublishRelease(graphene.Mutation):
         except Release.DoesNotExist:
             raise GraphQLError("The release was not found.")
 
-        try:
-            release.publish()
-            release.save()
-        except django_fsm.TransitionNotAllowed:
+        # Only allow a release to be published if it's staged
+        if release.state not in ["staged"]:
             raise GraphQLError(
                 f"The release in state {release.state} may not be published."
             )

--- a/tests/graphql/releases/test_publish_release.py
+++ b/tests/graphql/releases/test_publish_release.py
@@ -57,6 +57,7 @@ def test_publish_permissions(db, test_client, user_type, expected):
     if expected:
         assert "kfId" in resp.json()["data"]["publishRelease"]["release"]
     else:
+
         assert "errors" in resp.json()
         assert "Not authenticated" in resp.json()["errors"][0]["message"]
 
@@ -92,9 +93,11 @@ def test_publish_release_from_state(db, admin_client, mocker, state, allowed):
     if allowed:
         # Check that the release task was queued
         assert mock_rq.enqueue.call_count == 1
+        # The state shouldn't have changed yet as the publish task won't have
+        # been executed
         assert (
             resp.json()["data"]["publishRelease"]["release"]["state"]
-            == "publishing"
+            == "staged"
         )
     else:
         assert "errors" in resp.json()


### PR DESCRIPTION
Delays the state transition until the task worker picks up the actual action of publishing the release.