### PR TITLE
🔒 Make task updates protected

### DIFF
--- a/coordinator/permissions.py
+++ b/coordinator/permissions.py
@@ -54,10 +54,6 @@ class AdminOrReadOnlyPermission(permissions.BasePermission):
         # of an internal scheduler and made an admin-only action
         if view.action == "status_checks":
             return True
-        # We have to allow unauthenticated updates to tasks as some task
-        # services do not currently send us any authentication
-        if view.basename == "task" and view.action == 'partial_update':
-            return True
 
         if isinstance(request.user, AnonymousUser):
             return False

--- a/tests/failures/test_fail_run.py
+++ b/tests/failures/test_fail_run.py
@@ -69,9 +69,11 @@ def test_fail_running(admin_client, dev_client, client, transactional_db,
     task = resp.json()['results'][0]
 
     # Fail the task from the task service
-    resp = client.patch(BASE_URL+'/tasks/'+task['kf_id'],
-                        json.dumps({'state': 'failed'}),
-                        content_type='application/json')
+    resp = admin_client.patch(
+        BASE_URL + "/tasks/" + task["kf_id"],
+        json.dumps({"state": "failed"}),
+        content_type="application/json",
+    )
 
     worker.work(burst=True)
 
@@ -127,9 +129,11 @@ def test_cancel_running(admin_client, dev_client, client, transactional_db,
     task = resp.json()['results'][0]
 
     # Fail the task from the task service
-    resp = client.patch(BASE_URL+'/tasks/'+task['kf_id'],
-                        json.dumps({'state': 'canceled'}),
-                        content_type='application/json')
+    resp = admin_client.patch(
+        BASE_URL + "/tasks/" + task["kf_id"],
+        json.dumps({"state": "canceled"}),
+        content_type="application/json",
+    )
 
     worker.work(burst=True)
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -8,8 +8,8 @@ from coordinator.api.models import Release, Task, TaskService, Event
 BASE_URL = 'http://testserver'
 
 
-def test_full_release(client, dev_client, transactional_db, mocker, worker,
-                      study):
+def test_full_release(client, admin_client, dev_client, transactional_db,
+                      mocker, worker, study):
     """
     Test a full release:
     1) Create task service
@@ -110,9 +110,11 @@ def test_full_release(client, dev_client, transactional_db, mocker, worker,
     assert res['release'] == BASE_URL+'/releases/'+release_id
 
     # Send back a response to the coordinator mocking the task
-    resp = client.patch(BASE_URL+'/tasks/'+task_id,
-                        json.dumps({'progress': 50}),
-                        content_type='application/json')
+    resp = admin_client.patch(
+        BASE_URL + "/tasks/" + task_id,
+        json.dumps({"progress": 50}),
+        content_type="application/json",
+    )
     assert resp.status_code == 200
     res = resp.json()
     assert res['state'] == 'running'
@@ -120,9 +122,11 @@ def test_full_release(client, dev_client, transactional_db, mocker, worker,
 
     # Tell the coordinator the task has been staged
     # Send back a response to the coordinator mocking the task
-    resp = client.patch(BASE_URL+'/tasks/'+task_id,
-                        json.dumps({'state': 'staged', 'progress': 100}),
-                        content_type='application/json')
+    resp = admin_client.patch(
+        BASE_URL + "/tasks/" + task_id,
+        json.dumps({"state": "staged", "progress": 100}),
+        content_type="application/json",
+    )
 
     assert resp.status_code == 200
     res = resp.json()
@@ -146,9 +150,11 @@ def test_full_release(client, dev_client, transactional_db, mocker, worker,
     worker.work(burst=True)
 
     # Mock a task's response telling the coordinator it has published
-    resp = client.patch(BASE_URL+'/tasks/'+task_id,
-                        json.dumps({'state': 'published', 'progress': 100}),
-                        content_type='application/json')
+    resp = admin_client.patch(
+        BASE_URL + "/tasks/" + task_id,
+        json.dumps({"state": "published", "progress": 100}),
+        content_type="application/json",
+    )
     assert resp.status_code == 200
     res = resp.json()
     assert res['state'] == 'published'

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -29,14 +29,14 @@ STUDY_URL = f"{BASE_URL}/studies/"
         ("user", "/tasks", "get", 200),
         ("user", "/tasks", "post", 403),
         ("user", "/tasks/<kf_id>", "get", 200),
-        ("user", "/tasks/<kf_id>", "patch", 200),  # TODO: This shouldn't be ok
+        ("user", "/tasks/<kf_id>", "patch", 403),
         ("user", "/tasks/<kf_id>", "put", 403),
         ("user", "/tasks/<kf_id>", "delete", 403),
         # anon
         ("anon", "/tasks", "get", 200),
         ("anon", "/tasks", "post", 403),
         ("anon", "/tasks/<kf_id>", "get", 200),
-        ("anon", "/tasks/<kf_id>", "patch", 200),  # TODO: This shouldn't be ok
+        ("anon", "/tasks/<kf_id>", "patch", 403),
         ("anon", "/tasks/<kf_id>", "put", 403),
         ("anon", "/tasks/<kf_id>", "delete", 403),
     ],


### PR DESCRIPTION
Restricts updates to tasks to admins only.

Closes #178 