### PR TITLE
🐛 Add releated_name to release relationship

### DIFF
--- a/coordinator/api/models/release.py
+++ b/coordinator/api/models/release.py
@@ -76,7 +76,7 @@ class Release(models.Model):
     tags = ArrayField(models.CharField(max_length=50, blank=True),
                       blank=True, default=list,
                       help_text='Tags to group the release by')
-    studies = models.ManyToManyField(Study,
+    studies = models.ManyToManyField(Study, related_name="releases",
                                      help_text='kf_ids of the studies '
                                      'in this release')
     version = VersionField(partial=False, coerce=False,

--- a/coordinator/api/models/study.py
+++ b/coordinator/api/models/study.py
@@ -28,7 +28,7 @@ class Study(models.Model):
         """
         from coordinator.api.models.release import Release
         try:
-            return self.release_set.latest('created_at').version
+            return self.releases.latest('created_at').version
         except Release.DoesNotExist:
             return None
 
@@ -45,7 +45,7 @@ class Study(models.Model):
             return self._last_published_release
 
         try:
-            self._last_published_release = (self.release_set
+            self._last_published_release = (self.releases
                                                 .filter(state='published')
                                                 .latest('created_at'))
             return self._last_published_release

--- a/coordinator/api/views/studies.py
+++ b/coordinator/api/views/studies.py
@@ -62,4 +62,4 @@ class StudyReleasesViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         return Study.objects.get(kf_id=self.kwargs['study_kf_id']) \
-                            .release_set.order_by('-created_at')
+                            .releases.order_by('-created_at')

--- a/tests/test_studies.py
+++ b/tests/test_studies.py
@@ -21,7 +21,7 @@ def test_many_to_many_model(transactional_db, studies):
     assert len(Release.objects.first().studies.all()) == 2
 
     # Inspect from the study side
-    assert Study.objects.get(kf_id='SD_00000001').release_set.first() == r1
+    assert Study.objects.get(kf_id='SD_00000001').releases.first() == r1
 
     # Now make a new release
     r2 = Release(name='Release 2')
@@ -35,9 +35,9 @@ def test_many_to_many_model(transactional_db, studies):
     assert len(Release.objects.first().studies.all()) == 2
 
     # Inspect from the study side
-    assert Study.objects.get(kf_id='SD_00000001').release_set.count() == 2
-    assert Study.objects.get(kf_id='SD_00000000').release_set.count() == 1
-    assert Study.objects.get(kf_id='SD_00000002').release_set.count() == 1
+    assert Study.objects.get(kf_id='SD_00000001').releases.count() == 2
+    assert Study.objects.get(kf_id='SD_00000000').releases.count() == 1
+    assert Study.objects.get(kf_id='SD_00000002').releases.count() == 1
 
 
 def test_nested_releases(admin_client, transactional_db, release, studies):


### PR DESCRIPTION
Adds `related_name` to the study-release relationship so that the releases field is correctly resolved instead of being mapped to the `eleaseSet`field that is otherwise generated.