### PR TITLE
🔧 Remap port to standard coordinator service port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     volumes:
       - ./:/app/
     ports:
-      - '5000:5000'
+      - '5001:5000'
     environment:
       - PG_NAME=coordinator
       - PG_HOST=pg


### PR DESCRIPTION
Updates the port to 5001 which is the standard port assigned to the coordinator in the data stack.