### PR TITLE
🔧 Store cache in redis

### DIFF
--- a/coordinator/authentication.py
+++ b/coordinator/authentication.py
@@ -46,6 +46,7 @@ def get_service_token():
             url, headers=headers, json=data, timeout=settings.REQUEST_TIMEOUT
         )
         resp.raise_for_status()
+        logger.info(f"Retrieved a new client_credentials token from Auth0")
     except requests.exceptions.RequestException as err:
         logger.error(f"Problem retrieving access token from Auth0: {err}")
 

--- a/coordinator/settings/production.py
+++ b/coordinator/settings/production.py
@@ -128,18 +128,28 @@ DATABASES = {
 
 
 # Redis
+redis_host = os.environ.get("REDIS_HOST", "localhost")
+redis_port = os.environ.get("REDIS_PORT", 6379)
 RQ_QUEUES = {
-    'default': {
-        'HOST': os.environ.get('REDIS_HOST', 'localhost'),
-        'PORT': os.environ.get('REDIS_PORT', 6379),
-        'DB': 0,
-        'DEFAULT_TIMEOUT': 30,
+    "default": {
+        "HOST": redis_host,
+        "PORT": redis_port,
+        "DB": 0,
+        "DEFAULT_TIMEOUT": 30,
     },
-    'health_checks': {
-        'HOST': os.environ.get('REDIS_HOST', 'localhost'),
-        'PORT': os.environ.get('REDIS_PORT', 6379),
-        'DB': 0,
-        'DEFAULT_TIMEOUT': 30,
+    "health_checks": {
+        "HOST": redis_host,
+        "PORT": redis_port,
+        "DB": 0,
+        "DEFAULT_TIMEOUT": 30,
+    },
+}
+
+CACHES = {
+    "default": {
+        "BACKEND": "redis_cache.RedisCache",
+        "LOCATION": "{}:{}".format(redis_host, redis_port),
+        "OPTIONS": {"DB": 1},
     }
 }
 
@@ -147,6 +157,8 @@ redis_pass = os.environ.get('REDIS_PASS', False)
 if redis_pass:
     RQ_QUEUES['default']['PASSWORD'] = redis_pass
     RQ_QUEUES['health_checks']['PASSWORD'] = redis_pass
+    CACHES["default"]["OPTIONS"]["PASSWORD"] = redis_pass
+
 
 # EGO oauth creds
 EGO = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ drf-nested-routers==0.90.2
 boto3==1.9.112
 packaging==19.1
 graphene-django==2.5.0
+django-redis-cache==2.1.0


### PR DESCRIPTION
Replaces the default in memory cache to instead use redis as a backend.
This ensures that all tasks and the webserver can use the same token without unecessary calls to Auth0.

Closes #244 