### PR TITLE
👷 Publish to dockerhub action

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,29 +76,6 @@ jobs:
       - store_artifacts:
           path: test-reports
           destination: test-reports
-  publish:
-    docker:
-      - image: circleci/buildpack-deps:stretch
-    environment:
-      IMAGE_NAME: kfdrc/kf-api-release-coordinator
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: Build Docker Image
-          command: docker build --target dev -t $IMAGE_NAME:latest .
-      - run:
-          name: Publish Docker Image to Docker Hub
-          command: |
-            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USERNAME" --password-stdin
-            docker push $IMAGE_NAME:latest
-            export IMAGE_TAG=${CIRCLE_TAG/v/''}
-            export pat="^([0-9]+)\.([0-9]+)\.([0-9]+)$"
-            if [[ $IMAGE_TAG =~ $pat ]]; then
-                docker tag $IMAGE_NAME:latest $IMAGE_NAME:$IMAGE_TAG
-                docker push $IMAGE_NAME:$IMAGE_TAG
-            fi
-
 workflows:
   version: 2
   build:
@@ -108,7 +85,3 @@ workflows:
             branches:
               ignore:
                 - gh-pages
-      - publish:
-          filters:
-            branches:
-              only: master

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -1,0 +1,21 @@
+name: Docker Development Images
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login
+        run: echo $PASSWORD | docker login -u $USERNAME --password-stdin
+        env:
+          USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build image
+        run: docker build --target dev -t kfdrc/kf-api-release-coordinator:latest .
+      - name: Publish image
+        run: docker push kfdrc/kf-api-release-coordinator:latest

--- a/.github/workflows/gh_release.yml
+++ b/.github/workflows/gh_release.yml
@@ -1,0 +1,58 @@
+name: Release generator
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  create_release:
+    if: github.base_ref == 'master' && github.event.pull_request.merged && contains( github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Create tag from title and run asset script
+        id: find_tag_and_prepare_assets
+        run: |
+          TAG=$(echo ${{ github.event.pull_request.title }} | sed -E "s/^.*Release (.+\..+\..+)$/\1/g")
+          echo "::set-output name=tag::$TAG"
+
+          SCRIPT=.github/prepare_assets.sh
+          if [ -f $SCRIPT ]; then 
+            chmod u+x $SCRIPT
+            $SCRIPT $TAG
+          fi
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.find_tag_and_prepare_assets.outputs.tag }}
+          release_name: ${{ github.event.pull_request.title }}
+          body: ${{ github.event.pull_request.body }}
+          draft: false
+          prerelease: false
+
+      - name: Add latest-release tag
+        run: |
+          git tag -f latest-release
+          git push -f --tags
+      - name: Upload Assets
+        run: |
+          upload_url=${{ steps.create_release.outputs.upload_url }}
+          if [ -f .github/release_assets.txt ]; then
+            while IFS="" read -r FILE || [ -n "$FILE" ]
+            do
+              curl -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+                -H "Content-Type: $(file -b --mime-type $FILE)" \
+                --data-binary "@$FILE" \
+                "${upload_url%\{*}?name=$(basename $FILE)"
+            done < .github/release_assets.txt
+          fi


### PR DESCRIPTION
Builds and publishes a Docker image with GitHub actions to Dockerhub. This replaces the build and publish step in the circleci workflow to be consistent with the study creator CI.